### PR TITLE
feat: convertToBigInt 함수 수정/추가

### DIFF
--- a/src/controllers/convertToBigIntFromObjArray.js
+++ b/src/controllers/convertToBigIntFromObjArray.js
@@ -4,7 +4,7 @@
  * - 전체를 JSON.stringify한 후 다시 JSON.parse해 줌
  */
 
-export function convertBigIntToNumber(objArray) {
+export function convertToBigIntFromObjArray(objArray) {
   return objArray.map((obj) => {
     return JSON.parse(
       JSON.stringify(obj, (key, value) => {

--- a/src/controllers/convertToBigIntFromObject.js
+++ b/src/controllers/convertToBigIntFromObject.js
@@ -1,0 +1,13 @@
+/**
+ * express에서 bigint를 처리하기 위한 함수
+ * - 데이터 중 bigint인 것을 toString()한 후 Number로 변경
+ * - 전체를 JSON.stringify한 후 다시 JSON.parse해 줌
+ */
+
+export function convertToBigIntFromObject(obj) {
+  return JSON.parse(
+    JSON.stringify(obj, (key, value) => {
+      return typeof value === 'bigint' ? Number(value.toString()) : value;
+    })
+  );
+}

--- a/src/http/companies.http
+++ b/src/http/companies.http
@@ -1,3 +1,1 @@
 GET http://localhost:5500/api/companies
-
-// 자동 삭제 테스트

--- a/src/routes/getCompanies.js
+++ b/src/routes/getCompanies.js
@@ -1,7 +1,7 @@
 import express from 'express';
 import { PrismaClient } from '@prisma/client';
 import asyncHandler from '../controllers/asyncHandler.js';
-import { convertBigIntToNumber } from '../controllers/convertBigIntToNumber.js';
+import { convertToBigIntFromObjArray } from '../controllers/convertToBigIntFromObjArray.js';
 
 const router = express.Router();
 const prisma = new PrismaClient();
@@ -12,7 +12,7 @@ router.get(
   asyncHandler(async (req, res) => {
     const companies = await prisma.company.findMany();
     // 데이터 중 bigint를 number로 변경
-    const convertedCompanies = convertBigIntToNumber(companies);
+    const convertedCompanies = convertToBigIntFromObjArray(companies);
     res.send(convertedCompanies);
   })
 );


### PR DESCRIPTION
prisma schema를 보면 몇몇 데이터의 type이 BigInt인데 express에서는 이것을 바로 처리하지 못하며 이것을 Number로 변환한 객체를 전달해야함

- prisma를 통해 받아온 객체가 여러개(배열)인 경우: convertToBigIntFromObjArray 사용
- prisma를 통해 받아온 객체가 1개인 경우: convertToBigIntFromObject 사용

/src/controllers에 2개 함수 추가

기존의 convertToBigIntToNumber 함수의 이름을 convertToBigIntFromObjArray로 변경 convertToBigIntFromObject 함수를 추가(객체가 1개일때 사용)