### PR TITLE
[조형민] 기업 비교 관련 API 구현 완료 - Feature/13

### DIFF
--- a/server.js
+++ b/server.js
@@ -7,6 +7,7 @@ import getUsers from './src/routes/getUsers.js';
 import getLatestSelections from './src/routes/getLatestSelections.js';
 import patchUser from './src/routes/patchUser.js';
 import patchCompany from './src/routes/patchCompany.js';
+import getCompanyRank from './src/routes/getCompanyRank.js';
 
 dotenv.config();
 export const app = express();
@@ -30,5 +31,7 @@ app.use('/api', getLatestSelections);
 app.use('/api', patchUser);
 // 기업 정보 수정하기(조형민)
 app.use('/api', patchCompany);
+// 기업 순위 조회하기(조형민)
+app.use('/api', getCompanyRank);
 
 app.listen(process.env.PORT || 5500, () => console.log('Server Started'));

--- a/src/http/companies_jhm.http
+++ b/src/http/companies_jhm.http
@@ -5,6 +5,9 @@ GET http://localhost:5500/api/companies?limit=20
 GET http://localhost:5500/api/companies?orderBy=name
 
 ###
+GET http://localhost:5500/api/companies/1dcb892b-e818-4f1b-8f13-7ecf5aaf31d6/rank
+
+###
 PATCH  http://localhost:5500/api/companies/db1a0353-8e84-476c-9b52-53df166a3503
 Content-Type: application/json
 

--- a/src/routes/getCompanies.js
+++ b/src/routes/getCompanies.js
@@ -36,6 +36,16 @@ router.get(
           actualInvest: 'desc',
         };
         break;
+      case 'highestSimInvestment':
+        order = {
+          simInvest: 'asc',
+        };
+        break;
+      case 'lowestSimInvestment':
+        order = {
+          simInvest: 'desc',
+        };
+        break;
       case 'mostEmployees':
         order = {
           employeesCount: 'desc',
@@ -61,6 +71,7 @@ router.get(
         description: true,
         category: true,
         actualInvest: true,
+        simInvest: true,
         revenue: true,
         employeesCount: true,
         mySelectionCount: true,

--- a/src/routes/getCompanyRank.js
+++ b/src/routes/getCompanyRank.js
@@ -1,0 +1,45 @@
+// 조형민
+
+import express from 'express';
+import { PrismaClient } from '@prisma/client';
+import asyncHandler from '../controllers/asyncHandler.js';
+import { convertToBigIntFromObjArray } from '../controllers/convertToBigIntFromObjArray.js';
+
+const router = express.Router();
+const prisma = new PrismaClient();
+export default router;
+
+// 기업 순위 조회하기(인접한 상하위 2개의 기업 포함 총 5개 기업 정보 조회)
+router.get(
+  '/companies/:id/rank',
+  asyncHandler(async (req, res) => {
+    const { id } = req.params;
+    const companies = await prisma.company.findMany({ orderBy: { revenue: 'desc' } });
+    const myCompanyIdx = companies.findIndex((company) => company.id === id);
+    let rankCompanies;
+    if (companies.length < 5) {
+      rankCompanies = [...companies];
+    } else {
+      if (myCompanyIdx === 0 || myCompanyIdx === 1) {
+        rankCompanies = [companies[0], companies[1], companies[2], companies[3], companies[4]];
+      } else if (myCompanyIdx === companies.length - 1 || myCompanyIdx === companies.length - 2) {
+        rankCompanies = [
+          companies[companies.length - 5],
+          companies[companies.length - 4],
+          companies[companies.length - 3],
+          companies[companies.length - 2],
+          companies[companies.length - 1],
+        ];
+      } else {
+        rankCompanies = [
+          companies[myCompanyIdx - 2],
+          companies[myCompanyIdx - 1],
+          companies[myCompanyIdx],
+          companies[myCompanyIdx + 1],
+          companies[myCompanyIdx + 2],
+        ];
+      }
+    }
+    res.send(convertToBigIntFromObjArray(rankCompanies));
+  })
+);

--- a/src/routes/getCompanyRank.js
+++ b/src/routes/getCompanyRank.js
@@ -13,16 +13,50 @@ export default router;
 router.get(
   '/companies/:id/rank',
   asyncHandler(async (req, res) => {
+    const { orderBy = 'highestSales' } = req.query;
     const { id } = req.params;
-    const companies = await prisma.company.findMany({ orderBy: { revenue: 'desc' } });
+    let order;
+    switch (orderBy) {
+      case 'highestSales':
+        order = {
+          revenue: 'desc',
+        };
+        break;
+      case 'lowestSales':
+        order = {
+          revenue: 'asc',
+        };
+        break;
+      case 'mostEmployees':
+        order = {
+          employeesCount: 'desc',
+        };
+        break;
+      case 'fewestEmployees':
+        order = {
+          employeesCount: 'asc',
+        };
+        break;
+    }
+    const companies = await prisma.company.findMany({ orderBy: order });
     const myCompanyIdx = companies.findIndex((company) => company.id === id);
     let rankCompanies;
+    // 전체 기업 개수가 5보다 작으면 rank 정보만 추가
     if (companies.length < 5) {
       rankCompanies = [...companies];
+      rankCompanies.forEach((company, index) => {
+        company['rank'] = index + 1;
+      });
     } else {
+      // 내가 선택한 기업이 1위나 2위인 경우
       if (myCompanyIdx === 0 || myCompanyIdx === 1) {
         rankCompanies = [companies[0], companies[1], companies[2], companies[3], companies[4]];
-      } else if (myCompanyIdx === companies.length - 1 || myCompanyIdx === companies.length - 2) {
+        rankCompanies.forEach((company, index) => {
+          company['rank'] = index + 1;
+        });
+      }
+      // 내가 선택한 기업이 꼴지나 꼴지 앞자리인 경우
+      else if (myCompanyIdx === companies.length - 1 || myCompanyIdx === companies.length - 2) {
         rankCompanies = [
           companies[companies.length - 5],
           companies[companies.length - 4],
@@ -30,6 +64,9 @@ router.get(
           companies[companies.length - 2],
           companies[companies.length - 1],
         ];
+        rankCompanies.forEach((company, index) => {
+          company['rank'] = companies.length - 4 + index;
+        });
       } else {
         rankCompanies = [
           companies[myCompanyIdx - 2],
@@ -38,6 +75,9 @@ router.get(
           companies[myCompanyIdx + 1],
           companies[myCompanyIdx + 2],
         ];
+        rankCompanies.forEach((company, index) => {
+          company['rank'] = myCompanyIdx - 1 + index;
+        });
       }
     }
     res.send(convertToBigIntFromObjArray(rankCompanies));

--- a/src/routes/getLatestSelections.js
+++ b/src/routes/getLatestSelections.js
@@ -23,7 +23,19 @@ router.get(
     // 해당 id를 가진 기업 목록을 조회
     const selectedCompanies = await prisma.company.findMany({
       where: { id: { in: selectedIdsArray } },
-      select: { id: true, name: true, imageUrl: true, category: true, mySelectionCount: true },
+      select: {
+        id: true,
+        name: true,
+        imageUrl: true,
+        description: true,
+        category: true,
+        actualInvest: true,
+        simInvest: true,
+        revenue: true,
+        employeesCount: true,
+        mySelectionCount: true,
+        compareSelectionCount: true,
+      },
       // orderBy: { name: 'asc' },
     });
     res.send(convertToBigIntFromObjArray(selectedCompanies));


### PR DESCRIPTION
- getCompanies: 기업 목록 조회(팝업에서 기업 검색 시 사용하였으나 기업 목록 조회시 공통 사용 가능)
  - 정렬기준: 매출액, 누적투자, 가상투자, 고용인원, 기업명(오름차순)
  - skip(건너뛸 개수), limit(받아올 개수), searchString(검색어) 설정 가능
- getCompanyRank: 특정 기업의 순위 및 전후 2개 기업 조회(총 5개 기업 조회)
  - 기본 누적 투자 금액 내림차순  정렬
  - 리턴값에 rank정보를 포함하여 응답(해당 정보를 통해 프론트의 ‘기업 순위 확인하기’ 화면에서 순위를 출력
- getLatestSelections: 최근에 선택한 나의 기업 목록 5개 조회
  - 기본 기업명 오름차순 정렬
- patchCompany: 기업 정보 수정(선택횟수 반영을 위해 구현)
- patchUser: 사용자 정보 수정(최근 선택 기업 목록 저장을 위해 구현)
- getUsers: 사용자 전체 목록 조회(편의를 위해 구현)